### PR TITLE
Drop support for Python 3.6 and provide for versions up to 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,6 @@ orbs:
   python: circleci/python@1.3.2
 
 jobs:
-  test_py36:
-    docker:
-      - image: cimg/python:3.6.13
-    steps:
-      - checkout
-      - run: python setup.py bdist_wheel
-      - run: pip install -e .
-      - run: pip install tox
-      - run: tox -e py36
   test_py37:
     docker:
       - image: cimg/python:3.7.10
@@ -22,24 +13,57 @@ jobs:
       - run: pip install -e .
       - run: pip install tox
       - run: tox -e py37
+
   test_py38:
     docker:
-        - image: cimg/python:3.8.8
+      - image: cimg/python:3.8.8
     steps:
       - checkout
       - run: python setup.py bdist_wheel
       - run: pip install -e .
       - run: pip install tox
       - run: tox -e py38
+
   test_py39:
     docker:
-        - image: cimg/python:3.9.2
+      - image: cimg/python:3.9.2
     steps:
       - checkout
       - run: python setup.py bdist_wheel
       - run: pip install -e .
       - run: pip install tox
       - run: tox -e py39
+
+  test_py310:
+    docker:
+      - image: cimg/python:3.10.13
+    steps:
+      - checkout
+      - run: python setup.py bdist_wheel
+      - run: pip install -e .
+      - run: pip install tox
+      - run: tox -e py310
+
+  test_py311:
+    docker:
+      - image: cimg/python:3.11.4
+    steps:
+      - checkout
+      - run: python setup.py bdist_wheel
+      - run: pip install -e .
+      - run: pip install tox
+      - run: tox -e py311
+
+  test_py312:
+    docker:
+      - image: cimg/python:3.12.6
+    steps:
+      - checkout
+      - run: python setup.py bdist_wheel
+      - run: pip install -e .
+      - run: pip install tox
+      - run: tox -e py312
+
   pypi_distribution:
     docker:
       - image: cimg/python:3.9.2
@@ -47,26 +71,30 @@ jobs:
       - checkout
       - run:
           command: |
-              python setup.py bdist_wheel sdist
-              pip install --upgrade pip
-              pip install twine==3.3.0
-              twine upload --repository-url https://upload.pypi.org/legacy/ -u __token__ -p ${PYPI_PYTHON_KEYCLOAK_API_CLIENT_TOKEN} dist/*
+            python setup.py bdist_wheel sdist
+            pip install --upgrade pip
+            pip install twine==3.3.0
+            twine upload --repository-url https://upload.pypi.org/legacy/ -u __token__ -p ${PYPI_PYTHON_KEYCLOAK_API_CLIENT_TOKEN} dist/*
 
 workflows:
   version: 2
   app:
     jobs:
-      - test_py36
       - test_py37
       - test_py38
       - test_py39
+      - test_py310
+      - test_py311
+      - test_py312
       - approve_pypi_distribution:
           type: approval
           requires:
-            - test_py36
             - test_py37
             - test_py38
             - test_py39
+            - test_py310
+            - test_py311
+            - test_py312
           filters:
             branches:
               only:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ $ pip install -e .
 
 ## Changelog
 
+### v0.10.0
+- Dropped support for Python 3.6
+- Provided support for Python <=3.12
+
 ### v0.9.0
 - Added `delete_user` method.
 
@@ -55,7 +59,7 @@ $ pip install -e .
 - Added `limit` and `offset` params in `KeycloakApiClient.search_users()` to control paging
 
 ### v0.2.1
-- Fixed `StopIteration` when downloading user by email in case email partially matches found users but not exact match exact email 
+- Fixed `StopIteration` when downloading user by email in case email partially matches found users but not exact match exact email
 
 ### v0.2.0
 - Method `get_keycloak_user` was replaced by `get_keycloak_user_by_id` and `get_keycloak_user_by_email`

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,36 @@
 from setuptools import setup
 
 
-with open('README.md', 'r') as readme:
+with open("README.md", "r") as readme:
     long_description = readme.read()
 
 setup(
-    name='python-keycloak-api-client',
-    version='0.9.0',
-    description='Client for Keycloak Api (mostly users and impersonation)',
-    keywords='keycloak,client,api',
+    name="python-keycloak-api-client",
+    version="0.10.0",
+    description="Client for Keycloak Api (mostly users and impersonation)",
+    keywords="keycloak,client,api",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    author='Szymon Marcinkowski',
-    author_email='szymon@masterhub.com',
-    license='MIT',
-    url='https://github.com/masterplandev/python-keycloak-api-client',
-    packages=['keycloak_api_client'],
+    long_description_content_type="text/markdown",
+    author="Szymon Marcinkowski",
+    author_email="szymon@masterhub.com",
+    license="MIT",
+    url="https://github.com/masterplandev/python-keycloak-api-client",
+    packages=["keycloak_api_client"],
     classifiers=[
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
     ],
     install_requires=[
-        'attrs>=19.3',
-        'requests>=2.23',
+        "attrs>=19.3",
+        "requests>=2.23",
     ],
     extras_require={
-        'dev': [
-            'pytest>=6.2',
-            'flake8>=6.2',
+        "dev": [
+            "pytest>=6.2",
+            "flake8>=6.2",
         ]
-    }
+    },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}
+envlist = py{37,38,39,310,311,312}
 
 [testenv]
 deps =


### PR DESCRIPTION
- Dropped support for Python `3.6`
- Provided support for Python `<=3.12`