### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,6 @@ workflows:
   app:
     jobs:
       - test_python:
-          name: test_python_39
-          docker_image: "cimg/python:3.9.2"
-          tox_cmd: tox -e py39
-      - test_python:
           name: test_python_310
           docker_image: "cimg/python:3.10.13"
           tox_cmd: tox -e py310
@@ -54,7 +50,6 @@ workflows:
       - approve_pypi_distribution:
           type: approval
           requires:
-            - test_python_39
             - test_python_310
             - test_python_311
             - test_python_312

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## v0.11.0
-- Dropped support for Python `3.7` and `3.8`
+- Dropped support for older Python versions (`3.7`, `3.8` and `3.9`)
 - Adjusted typing for modern Python
 
 ## v0.10.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312}
+envlist = py{310,311,312}
 
 [testenv]
 extras = dev


### PR DESCRIPTION
- Drop support for Python 3.9