### PR TITLE
[MP-15122] Keycloak API client casts None to string resulting in "None"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,70 +1,95 @@
 # Changelog
 
+## v0.13.2
+
+- Make `first_name` and `last_name` optional in `BaseKeycloakUser` as they can be `None`
+- Fix issue: `first_name` and `last_name` of `BaseKeycloakUser` are no longer casted to string if they are `None`
+
 ## v0.13.1
+
 - Add a check for the expiration of the admin user token
 
 ## v0.13.0
+
 - Added CI badges
 - Add general readme info
 
 ## v0.12.0
+
 - Provided option for [relative path](https://www.keycloak.org/server/all-config?q=relative-path) configuration
 - Adjusted scope of client private properties
 - Provided extra consistency when casting responses to objects
 - Deleted unused `token_exchange_target_client_id` attribute
 
 ## v0.11.0
+
 - Dropped support for older Python versions (`3.7`, `3.8` and `3.9`)
 - Adjusted typing for modern Python
 
 ## v0.10.1
+
 - Fix failing tests due to `vcr` not being able to decode binary responses for Python>=3.9
 - Delete some ALB related cookie leftovers
 - Replace `flake` with `ruff`
 
 ## v0.10.0
+
 - Dropped support for Python `3.6`
 - Provided support for Python `<=3.12`
 
 ## v0.9.0
+
 - Added `delete_user` method.
 
 ## v0.8.1
+
 - Clear `admin_user_access_token` before using token-exchange feature.
 
 ## v0.8.0
+
 - Allow to define starting `client_id` / `client_secret` when using token-exchange feature
 
 ## v0.7.1
+
 - Change `client_id` value in `get_user_tokens`
 
 ## v0.7.0
+
 - Added methods `search_clients_by_client_id` and `delete_client`
 - Added `KeycloakClient` dataclass
 
 ## v0.6.0
+
 - Added methods `create_client` and `create_mapper_for_client`
 
 ## v0.5.0
+
 - Added method `send_verification_email`
 
 ## v0.4.0
+
 - Added method `reset_password`
 
 ## v0.3.0
+
 - Added method `count_users`
 
 ## v0.2.2
+
 - Added `limit` and `offset` params in `KeycloakApiClient.search_users()` to control paging
 
 ## v0.2.1
+
 - Fixed `StopIteration` when downloading user by email in case email partially matches found users but not exact match exact email
 
 ## v0.2.0
+
 - Method `get_keycloak_user` was replaced by `get_keycloak_user_by_id` and `get_keycloak_user_by_email`
 
 ## v0.1.1
+
 - Fixed typo
 
 ## v0.1.0
+
 - Initial release

--- a/keycloak_api_client/data_classes.py
+++ b/keycloak_api_client/data_classes.py
@@ -13,8 +13,8 @@ class KeycloakFederatedIdentity:
 @attr.s(auto_attribs=True)
 class BaseKeycloakUser:
     username: str
-    first_name: str
-    last_name: str
+    first_name: str | None
+    last_name: str | None
     email: str
     enabled: bool
     email_verified: bool

--- a/keycloak_api_client/factories.py
+++ b/keycloak_api_client/factories.py
@@ -6,14 +6,18 @@ from attrs.converters import to_bool
 from keycloak_api_client.data_classes import ReadKeycloakUser, KeycloakClient
 
 
-def read_keycloak_user_factory(
-    user_endpoint_data: dict[str, Any],
-) -> ReadKeycloakUser:
+def read_keycloak_user_factory(user_endpoint_data: dict[str, Any]) -> ReadKeycloakUser:
+    def _get_casted_value_if_present(val: Any | None, cast: type) -> Any | None:
+        if val:
+            return cast(val)
+
     return ReadKeycloakUser(
         keycloak_id=UUID(user_endpoint_data.get("id")),
         username=str(user_endpoint_data.get("username")),
-        first_name=str(user_endpoint_data.get("firstName")),
-        last_name=str(user_endpoint_data.get("lastName")),
+        first_name=_get_casted_value_if_present(
+            user_endpoint_data.get("firstName"), str
+        ),
+        last_name=_get_casted_value_if_present(user_endpoint_data.get("lastName"), str),
         email=str(user_endpoint_data.get("email")),
         enabled=to_bool(str(user_endpoint_data.get("enabled"))),
         email_verified=to_bool(str(user_endpoint_data.get("emailVerified"))),

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name="python-keycloak-api-client",
-    version="0.13.1",
+    version="0.13.2",
     description="Client for Keycloak Api (mostly users and impersonation)",
     keywords="keycloak,client,api",
     long_description=long_description,

--- a/tests/factories_test.py
+++ b/tests/factories_test.py
@@ -7,7 +7,7 @@ from keycloak_api_client.factories import (
 
 
 def test_create_user_from_keycloak_data():
-    data = {
+    data1 = {
         "id": "3f169eaa-8405-46e0-b106-e4f1823331e1",
         "createdTimestamp": 1590563321150,
         "username": "any@test.com",
@@ -37,16 +37,57 @@ def test_create_user_from_keycloak_data():
         },
     }
 
-    keycloak_user = read_keycloak_user_factory(user_endpoint_data=data)
+    keycloak_user1 = read_keycloak_user_factory(user_endpoint_data=data1)
 
-    assert keycloak_user.keycloak_id == UUID("3f169eaa-8405-46e0-b106-e4f1823331e1")
-    assert keycloak_user.username == "any@test.com"
-    assert keycloak_user.first_name == "name"
-    assert keycloak_user.last_name == "surname"
-    assert keycloak_user.email == "any@test.com"
-    assert keycloak_user.enabled
-    assert keycloak_user.email_verified
-    assert keycloak_user.raw_data == data
+    assert keycloak_user1.keycloak_id == UUID("3f169eaa-8405-46e0-b106-e4f1823331e1")
+    assert keycloak_user1.username == "any@test.com"
+    assert keycloak_user1.first_name == "name"
+    assert keycloak_user1.last_name == "surname"
+    assert keycloak_user1.email == "any@test.com"
+    assert keycloak_user1.enabled
+    assert keycloak_user1.email_verified
+    assert keycloak_user1.raw_data == data1
+
+    data2 = {
+        "id": "3f169eaa-8405-46e0-b106-e4f1823331e1",
+        "createdTimestamp": 1590563321150,
+        "username": "any@test.com",
+        "enabled": True,
+        "totp": False,
+        "emailVerified": True,
+        "firstName": None,
+        "lastName": None,
+        "email": "any@test.com",
+        "attributes": {
+            "legacy_user_id": ["281eecba-da9f-4806-835d-59eb06856f32"],
+            "company_id": ["f4be2d0f-af90-07b0-44b9-05629d2cb8de"],
+            "phone": ["111222333"],
+            "date_of_birth": ["2000-11-13"],
+            "title": ["mr"],
+            "job_title": ["job_title"],
+        },
+        "disableableCredentialTypes": [],
+        "requiredActions": [],
+        "notBefore": 0,
+        "access": {
+            "manageGroupMembership": True,
+            "view": True,
+            "mapRoles": True,
+            "impersonate": True,
+            "manage": True,
+        },
+    }
+
+    keycloak_user2 = read_keycloak_user_factory(user_endpoint_data=data2)
+
+    assert keycloak_user2.keycloak_id == UUID("3f169eaa-8405-46e0-b106-e4f1823331e1")
+    assert keycloak_user2.username == "any@test.com"
+    assert not keycloak_user2.first_name
+    assert not keycloak_user2.last_name
+    assert keycloak_user2.email == "any@test.com"
+    assert keycloak_user2.enabled
+    assert keycloak_user2.email_verified
+    assert keycloak_user2.raw_data == data2
 
 
 def test_keycloak_client_factory():


### PR DESCRIPTION
## v0.13.2

- Make `first_name` and `last_name` optional in `BaseKeycloakUser` as they can be `None`
- Fix issue: `first_name` and `last_name` of `BaseKeycloakUser` are no longer casted to string if they are `None`